### PR TITLE
Add PDG Options to MC Drawing

### DIFF
--- a/webevd/WebEVD/WebEVDServer.cxx
+++ b/webevd/WebEVD/WebEVDServer.cxx
@@ -425,20 +425,20 @@ JSONFormatter& operator<<(JSONFormatter& json, const recob::Track& track)
     pts.emplace_back(pt.X(), pt.Y(), pt.Z());
   }
 
-  return json << pts;
+  return json << "{ positions: " << pts << " }";
 }
 
 // ----------------------------------------------------------------------------
 JSONFormatter& operator<<(JSONFormatter& json, const simb::MCParticle& part)
 {
   const int apdg = abs(part.PdgCode());
-  if(apdg == 12 || apdg == 14 || apdg == 16) return json << "[]"; // decay neutrinos
+  if(apdg == 12 || apdg == 14 || apdg == 16) return json << "{ positions: [] }"; // decay neutrinos
   std::vector<TVector3> pts;
   for(unsigned int j = 0; j < part.NumberTrajectoryPoints(); ++j){
     pts.emplace_back(part.Vx(j), part.Vy(j), part.Vz(j));
   }
 
-  return json << pts;
+  return json << "{ pdg: " << apdg << ", positions: " << pts << " }";
 }
 
 // ----------------------------------------------------------------------------

--- a/webevd/WebEVD/web/evd.js
+++ b/webevd/WebEVD/web/evd.js
@@ -582,13 +582,23 @@ function add_tracks(trajs, group, must_be_charged){
             col = other_colours[i % other_colours.length];
 
         i += 1;
-        let mat_trk = new THREE.LineBasicMaterial({color: col, linewidth: 2});
-        let trkgeom = new THREE.BufferGeometry();
         let ptarr = [];
         for(let pt of track.positions) ptarr = ptarr.concat(pt);
+
+        let trkgeom = new THREE.BufferGeometry();
         trkgeom.setAttribute('position', new THREE.BufferAttribute(new Float32Array(ptarr), 3));
 
-        let trkline = new THREE.Line(trkgeom, mat_trk);
+        // Draw track-like as a line.
+        // Draw shower-like as a point cloud.
+        let trkline = undefined
+        if (('pdg' in track) && (track.pdg == '11' || track.pdg == '22')) {
+            let mat_trk = new THREE.LineBasicMaterial({color: col, linewidth: 3});
+            trkline = new THREE.Points(trkgeom, mat_trk);
+        } else {
+            let mat_trk = new THREE.LineBasicMaterial({color: col, linewidth: 2});
+            trkline = new THREE.Line(trkgeom, mat_trk);
+        }
+
         for(let i = 0; i <= 5; ++i) trkline.layers.enable(i);
         group.add(trkline);
     }

--- a/webevd/WebEVD/web/evd.js
+++ b/webevd/WebEVD/web/evd.js
@@ -167,8 +167,6 @@ function FinalizeTextures(){
                                            });
         } // end for fname
     } // end for d
-
-    return mat;
 }
 
 

--- a/webevd/WebEVD/web/evd.js
+++ b/webevd/WebEVD/web/evd.js
@@ -586,16 +586,8 @@ function add_tracks(trajs, group, must_be_charged){
         let trkgeom = new THREE.BufferGeometry();
         trkgeom.setAttribute('position', new THREE.BufferAttribute(new Float32Array(ptarr), 3));
 
-        // Draw track-like as a line.
-        // Draw shower-like as a point cloud.
-        let trkline = undefined
-        if (('pdg' in track) && (track.pdg == '11' || track.pdg == '22')) {
-            let mat_trk = new THREE.LineBasicMaterial({color: col, linewidth: 3});
-            trkline = new THREE.Points(trkgeom, mat_trk);
-        } else {
-            let mat_trk = new THREE.LineBasicMaterial({color: col, linewidth: 2});
-            trkline = new THREE.Line(trkgeom, mat_trk);
-        }
+        let mat_trk = new THREE.LineBasicMaterial({color: col, linewidth: 2});
+        let trkline = trkline = new THREE.Line(trkgeom, mat_trk);
 
         for(let i = 0; i <= 5; ++i) trkline.layers.enable(i);
         group.add(trkline);

--- a/webevd/WebEVD/web/evd.js
+++ b/webevd/WebEVD/web/evd.js
@@ -176,9 +176,11 @@ let outlines = new THREE.Group();
 let digs = {}; // Groups indexed by label
 let wires = {};
 let truth = new THREE.Group();
+let chargedTruth = new THREE.Group();
 
 scene.add(outlines);
 scene.add(truth);
+scene.add(chargedTruth);
 
 let com = new THREE.Vector3();
 let nplanes = 0;
@@ -564,17 +566,26 @@ for(let label in spacepoints){
 }
 
 
-let colors = ['red', 'blue', 'green', 'orange', 'purple', 'skyblue'];
+let other_colours = ['green', 'purple', 'pink', 'red', 'violet']
+let pdg_colours = {'13': 'blue', '11': 'skyblue', '2212': 'orange', '211': 'magenta'}
 
-function add_tracks(trajs, group){
+function add_tracks(trajs, group, must_be_charged){
     let i = 0;
     for(let track of trajs){
-        let col = colors[i%colors.length];
+        let col = 'white';
+
+        if (('pdg' in track) && (track.pdg in pdg_colours))
+            col = pdg_colours[track.pdg];
+        else if (must_be_charged)
+            continue;
+        else
+            col = other_colours[i % other_colours.length];
+
         i += 1;
         let mat_trk = new THREE.LineBasicMaterial({color: col, linewidth: 2});
         let trkgeom = new THREE.BufferGeometry();
         let ptarr = [];
-        for(let pt of track) ptarr = ptarr.concat(pt);
+        for(let pt of track.positions) ptarr = ptarr.concat(pt);
         trkgeom.setAttribute('position', new THREE.BufferAttribute(new Float32Array(ptarr), 3));
 
         let trkline = new THREE.Line(trkgeom, mat_trk);
@@ -591,7 +602,8 @@ for(let label in tracks){
     AddDropdownToggle('tracks_dropdown', reco_tracks, label);
 }
 
-add_tracks(truth_trajs, truth);
+add_tracks(truth_trajs, truth, 0);
+add_tracks(truth_trajs, chargedTruth, 1);
 
 
 for(let label in xdigs){
@@ -812,7 +824,8 @@ function ToggleLabel(col, id, str){
 
 // TODO - would be better to have this javascript look up the buttons in the
 // HTML and attach the handlers to them.
-window.ToggleTruth = function(){Toggle(truth, 'truth', 'Truth');}
+window.ToggleAllTruth = function(){Toggle(truth, 'allTruth', 'All');}
+window.ToggleChargedTruth = function(){Toggle(chargedTruth, 'chargedTruth', 'Charged');}
 window.ToggleCryos = function(){Toggle(cryogroup, 'cryos', 'Cryostats');}
 window.ToggleAPAs = function(){Toggle(apas, 'apas', 'APAs');}
 window.ToggleOpDets = function(){Toggle(opdetgroup, 'opdets', 'OpDets');}
@@ -826,7 +839,8 @@ ThreeDControls();
 
 //SetVisibilityById(digs, false, 'rawdigits', 'RawDigits');
 //SetVisibilityById(wires, false, 'wires', 'Wires');
-SetVisibilityById(truth, true, 'truth', 'Truth');
+SetVisibilityById(truth, true, 'allTruth', 'All');
+SetVisibilityById(chargedTruth, false, 'chargedTruth', 'Charged');
 
 SetVisibilityById(cryogroup, true, 'cryos', 'Cryostats');
 SetVisibilityById(apas, true, 'apas', 'APAs');

--- a/webevd/WebEVD/web/evd.js
+++ b/webevd/WebEVD/web/evd.js
@@ -609,7 +609,7 @@ function add_tracks(trajs, group, must_be_charged){
         trkgeom.setAttribute('position', new THREE.BufferAttribute(new Float32Array(ptarr), 3));
 
         let mat_trk = new THREE.LineBasicMaterial({color: col, linewidth: 2});
-        let trkline = trkline = new THREE.Line(trkgeom, mat_trk);
+        let trkline = new THREE.Line(trkgeom, mat_trk);
 
         for(let i = 0; i <= 5; ++i) trkline.layers.enable(i);
         group.add(trkline);

--- a/webevd/WebEVD/web/evd.js
+++ b/webevd/WebEVD/web/evd.js
@@ -610,8 +610,8 @@ for(let label in tracks){
     AddDropdownToggle('tracks_dropdown', reco_tracks, label);
 }
 
-add_tracks(truth_trajs, truth, 0);
-add_tracks(truth_trajs, chargedTruth, 1);
+add_tracks(truth_trajs, truth, false);
+add_tracks(truth_trajs, chargedTruth, true);
 
 
 for(let label in xdigs){

--- a/webevd/WebEVD/web/evd.js
+++ b/webevd/WebEVD/web/evd.js
@@ -563,21 +563,43 @@ for(let label in spacepoints){
     AddDropdownToggle('spacepoints_dropdown', sps, label);
 }
 
+// Consistent colouring for each PDG.
+// Declared outside the function to ensure consistency across the many times
+// add_tracks is run.
+let colour_map = {};
+let colours = ['blue', 'skyblue', 'orange', 'magenta', 'green', 'purple', 'pink', 'red', 'violet', 'yellow']
+let neutral_particles = [-1, 22, 111, 2112, 311]
 
-let other_colours = ['green', 'purple', 'pink', 'red', 'violet']
-let pdg_colours = {'13': 'blue', '11': 'skyblue', '2212': 'orange', '211': 'magenta'}
+function is_neutral(pdg) {
+    if (neutral_particles.includes(pdg))
+        return true;
+    else if (pdg.length >= 10) // Nuclei
+        return true;
+
+    return false;
+}
 
 function add_tracks(trajs, group, must_be_charged){
     let i = 0;
     for(let track of trajs){
         let col = 'white';
+        let track_pdg = 'pdg' in track ? track.pdg : -1;
 
-        if (('pdg' in track) && (track.pdg in pdg_colours))
-            col = pdg_colours[track.pdg];
-        else if (must_be_charged)
+        if (is_neutral(track_pdg) && must_be_charged)
             continue;
-        else
-            col = other_colours[i % other_colours.length];
+
+        if (track_pdg in colour_map)
+            col = colour_map[track_pdg];
+        else if (track_pdg != -1){
+            if (is_neutral(track_pdg))
+                col = 'grey';
+            else
+                col = colours[i % colours.length];
+
+            colour_map[track_pdg] = col;
+        } else {
+            col = colours[i % colours.length];
+        }
 
         i += 1;
         let ptarr = [];
@@ -596,7 +618,7 @@ function add_tracks(trajs, group, must_be_charged){
 
 for(let label in tracks){
     let reco_tracks = new THREE.Group();
-    add_tracks(tracks[label], reco_tracks);
+    add_tracks(tracks[label], reco_tracks, false);
     scene.add(reco_tracks);
 
     AddDropdownToggle('tracks_dropdown', reco_tracks, label);

--- a/webevd/WebEVD/web/index.html
+++ b/webevd/WebEVD/web/index.html
@@ -114,7 +114,13 @@
         </div>
       </div>
 
-      <button id="truth" onclick="ToggleTruth()"></button>
+      <div class="dropdown">
+        <button>MC Truth...</button>
+        <div class="dropdown-content">
+          <button id="allTruth" onclick="ToggleAllTruth()"></button>
+          <button id="chargedTruth" onclick="ToggleChargedTruth()"></button>
+        </div>
+      </div>
 
     </div> <!-- position:absolute -->
 


### PR DESCRIPTION
This adds the saving of the PDG code for the MC, so that the drawing can depend on it and we can:

 - Colour charged particles in a consistent way
 - Only draw particles of interest (i.e. ones that are actually visible in the detector)

Without:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/10038688/84822983-8297a700-b015-11ea-9a1c-3d6879737edf.png">

With, and only charged:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/10038688/84822998-8a574b80-b015-11ea-9def-bf43d757bd84.png">


Things that may want a look over:

 - How complete the PDG-to-colour dict needs to be, right now its "good enough".
 - If there is anything horrific about the colours I've chosen (somewhat based on the Pandora colours, just with the same colour for particle/antiparticle).