### PR TITLE
Encode pngs lazily

### DIFF
--- a/webevd/WebEVD/PNGArena.cxx
+++ b/webevd/WebEVD/PNGArena.cxx
@@ -9,15 +9,15 @@
 namespace evd
 {
   // --------------------------------------------------------------------------
-  PNGArena::PNGArena(const std::string& n) : name(n), extent(kArenaSize), nviews(0)
+  PNGArena::PNGArena(const std::string& n) : name(n), nviews(0)
   {
   }
 
   // --------------------------------------------------------------------------
   png_byte* PNGArena::NewBlock()
   {
-    const int nfitx = extent/kBlockSize;
-    const int nfity = extent/kBlockSize;
+    const int nfitx = kArenaSize/kBlockSize;
+    const int nfity = kArenaSize/kBlockSize;
 
     int ix = nviews%nfitx;
     int iy = nviews/nfitx;
@@ -26,12 +26,108 @@ namespace evd
       ix = 0;
       iy = 0;
       nviews = 0;
-      data.emplace_back(4*extent*extent);
+      data.push_back(std::make_unique<std::array<png_byte, kTotBytes>>());
+      data.back()->fill(0);
+      fHasMIP.push_back(false);
+      fMIPLocks.push_back(new std::mutex);
     }
 
     ++nviews;
 
-    return &data.back()[(iy*extent + ix)*kBlockSize*4];
+    return &(*data.back())[(iy*kArenaSize + ix)*kBlockSize*4];
+  }
+
+  // --------------------------------------------------------------------------
+  void PNGArena::FillMipMaps(int d)// const
+  {
+    png_byte* src = &(*data[d])[0];
+    png_byte* dest = &(*data[d])[kArenaSize*kArenaSize*4];
+
+    for(int newdim = kArenaSize/2; newdim >= 1; newdim /= 2){
+      const int olddim = newdim*2;
+
+      // The alpha channel is set to twice the average of the source
+      // pixels. The intuition is that a linear feature should remain equally
+      // as bright, but would be expected to only hit 2 of the 4 source
+      // pixels. The colour channels are averaged, weighted by the alpha
+      // values.
+      for(int y = 0; y < newdim; ++y){
+        for(int x = 0; x < newdim; ++x){
+          int totc[3] = {0,};
+          int tota = 0;
+          for(int dy = 0; dy <= 1; ++dy){
+            for(int dx = 0; dx <= 1; ++dx){
+              const int i = (y*2+dy)*olddim + (x*2+dx);
+
+              const png_byte va = src[i*4+3]; // alpha value
+              tota += va;
+
+              for(int c = 0; c < 3; ++c){
+                const png_byte vc = src[i*4+c]; // colour value
+                totc[c] += vc * va;
+              } // end for c
+            } // end for dx
+          } // end for dy
+
+          const int i = y*newdim+x;
+          for(int c = 0; c < 3; ++c) dest[i*4+c] = tota > 0 ? std::min(totc[c]/tota, 255) : 0;
+          dest[i*4+3] = std::min(tota/2, 255);
+        } // end for x
+      } // end for y
+
+      src = dest;
+      dest += 4*newdim*newdim;
+    } // end for newdim
+  }
+
+  // --------------------------------------------------------------------------
+  void PNGArena::WritePNGBytes(FILE* fout, int imgIdx, int dim)
+  {
+    if(imgIdx >= int(data.size())){
+      std::cout << "Bad index " << imgIdx << std::endl;
+      return; // TODO return 404 instead
+    }
+
+    if(dim != kArenaSize){ // might need MIPMaps generated
+      std::lock_guard<std::mutex> guard(*fMIPLocks[imgIdx]);
+      if(!fHasMIP[imgIdx]){
+        FillMipMaps(imgIdx);
+        fHasMIP[imgIdx] = true;
+      }
+    }
+
+    // Figure out offset
+    png_byte* src = &(*data[imgIdx])[MipMapOffset(dim, kArenaSize)];
+
+    if(src + 4*dim*dim - 1 > &(*data[imgIdx]).back()){ // would run off end of data
+      std::cout << "Bad mipmap size " << dim << std::endl;
+      return; // TODO return 404 instead
+    }
+
+    png_struct_def* png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+
+    auto info_ptr = png_create_info_struct(png_ptr);
+
+    // I'm trying to optimize the compression speed, without blowing the file
+    // size up. It's far from clear these are the best parameters, but they do
+    // seem to be an improvement on the defaults.
+    png_set_compression_level(png_ptr, 1);
+    png_set_compression_strategy(png_ptr, Z_RLE);
+
+    png_set_IHDR(png_ptr, info_ptr, dim, dim,
+                 8/*bit_depth*/, PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE,
+                 PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
+
+    std::vector<png_byte*> pdatas(dim);
+    for(int i = 0; i < dim; ++i) pdatas[i] = src + i*dim*4;
+
+    png_set_rows(png_ptr, info_ptr, &pdatas.front());
+
+    png_init_io(png_ptr, fout);
+
+    png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
+
+    png_destroy_write_struct(&png_ptr, &info_ptr);
   }
 
   // --------------------------------------------------------------------------
@@ -41,44 +137,13 @@ namespace evd
   }
 
   // --------------------------------------------------------------------------
-  void MipMap(PNGArena& bytes, int newdim)
-  {
-    // The alpha channel is set to twice the average of the source pixels. The
-    // intuition is that a linear feature should remain equally as bright, but
-    // would be expected to only hit 2 of the 4 source pixels. The colour
-    // channels are averaged, weighted by the alpha values.
-    for(unsigned int d = 0; d < bytes.data.size(); ++d){
-      for(int y = 0; y < newdim; ++y){
-        for(int x = 0; x < newdim; ++x){
-          int totc[3] = {0,};
-          int tota = 0;
-          for(int dy = 0; dy <= 1; ++dy){
-            for(int dx = 0; dx <= 1; ++dx){
-              const png_byte va = bytes(d, x*2+dx, y*2+dy, 3); // alpha value
-              tota += va;
-
-              for(int c = 0; c < 3; ++c){
-                const png_byte vc = bytes(d, x*2+dx, y*2+dy, c); // colour value
-                totc[c] += vc * va;
-              } // end for c
-            } // end for dx
-          } // end for dy
-
-          for(int c = 0; c < 3; ++c) bytes(d, x, y, c) = tota > 0 ? std::min(totc[c]/tota, 255) : 0;
-          bytes(d, x, y, 3) = std::min(tota/2, 255);
-        } // end for x
-      } // end for y
-    } // end for d
-  }
-
-  // --------------------------------------------------------------------------
   void AnalyzeArena(const PNGArena& bytes)
   {
-    for(int blockSize = 1; blockSize <= bytes.extent; blockSize *= 2){
+    for(int blockSize = 1; blockSize <= PNGArena::kArenaSize; blockSize *= 2){
       long nfilled = 0;
       for(unsigned int d = 0; d < bytes.data.size(); ++d){
-        for(int iy = 0; iy < bytes.extent/blockSize; ++iy){
-          for(int ix = 0; ix < bytes.extent/blockSize; ++ix){
+        for(int iy = 0; iy < PNGArena::kArenaSize/blockSize; ++iy){
+          for(int ix = 0; ix < PNGArena::kArenaSize/blockSize; ++ix){
             bool filled = false;
             for(int y = 0; y < blockSize && !filled; ++y){
               for(int x = 0; x < blockSize; ++x){
@@ -93,72 +158,7 @@ namespace evd
         }
       }
 
-      std::cout << "With block size = " << blockSize << " " << double(nfilled)/((bytes.extent*bytes.extent)/(blockSize*blockSize)*bytes.data.size()) << " of the blocks are filled" << std::endl;
-    }
-  }
-
-  void _WriteToPNG(Temporaries* tmp,
-                   const std::string prefix,
-                   const PNGArena* bytes,
-                   int mipmapdim,
-                   int d)
-  {
-    const std::string fname = TString::Format("%s_%d_mip%d.png", prefix.c_str(), d, mipmapdim).Data();
-
-    FILE* fp = tmp->fopen(fname.c_str(), "wb");
-
-    png_struct_def* png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-    auto info_ptr = png_create_info_struct(png_ptr);
-
-    // I'm trying to optimize the compression speed, without blowing the file
-    // size up. It's far from clear these are the best parameters, but they do
-    // seem to be an improvement on the defaults.
-    png_set_compression_level(png_ptr, 1);
-    png_set_compression_strategy(png_ptr, Z_RLE);
-
-    png_init_io(png_ptr, fp);
-    png_set_IHDR(png_ptr, info_ptr, mipmapdim, mipmapdim,
-                 8/*bit_depth*/, PNG_COLOR_TYPE_RGBA/*GRAY*/, PNG_INTERLACE_NONE,
-                 PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
-
-    std::vector<png_byte*> pdatas(mipmapdim);
-    for(int i = 0; i < mipmapdim; ++i) pdatas[i] = const_cast<png_byte*>(&(*bytes)(d, 0, i, 0));
-    png_set_rows(png_ptr, info_ptr, &pdatas.front());
-
-    png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
-
-    fclose(fp);
-
-    png_destroy_write_struct(&png_ptr, &info_ptr);
-  }
-
-  // --------------------------------------------------------------------------
-  void WriteToPNG(Temporaries& tmp,
-                  const std::string& prefix,
-                  const PNGArena& bytes,
-                  int mipmapdim)
-  {
-    if(mipmapdim == -1) mipmapdim = bytes.extent;
-
-    std::vector<std::thread> threads;
-    threads.reserve(bytes.data.size());
-
-    for(unsigned int d = 0; d < bytes.data.size(); ++d){
-      threads.emplace_back(_WriteToPNG, &tmp, prefix, &bytes, mipmapdim, d);
-    }
-
-    for(std::thread& t: threads) t.join();
-  }
-
-  // --------------------------------------------------------------------------
-  void WriteToPNGWithMipMaps(Temporaries& tmp,
-                             const std::string& prefix, PNGArena& bytes)
-  {
-    //  AnalyzeArena(bytes);
-
-    for(int mipmapdim = bytes.extent; mipmapdim >= 1; mipmapdim /= 2){
-      WriteToPNG(tmp, prefix, bytes, mipmapdim);
-      MipMap(bytes, mipmapdim/2);
+      std::cout << "With block size = " << blockSize << " " << double(nfilled)/((PNGArena::kArenaSize*PNGArena::kArenaSize)/(blockSize*blockSize)*bytes.data.size()) << " of the blocks are filled" << std::endl;
     }
   }
 

--- a/webevd/WebEVD/PNGArena.h
+++ b/webevd/WebEVD/PNGArena.h
@@ -3,6 +3,7 @@
 
 #include "webevd/WebEVD/Temporaries.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -12,38 +13,56 @@ namespace evd
 {
   class JSONFormatter;
 
+  static constexpr int MipMapOffset(int dim, int maxdim)
+  {
+    if(dim >= maxdim) return 0;
+    return MipMapOffset(dim*2, maxdim) + (dim*2)*(dim*2)*4;
+  }
+
   class PNGArena
   {
   public:
+    friend class PNGView;
+    friend void AnalyzeArena(const PNGArena&);
+
     enum{
       // Square because seems to be necessary for mipmapping. Larger than this
       // doesn't seem to work in the browser.
       kArenaSize = 4096,
       // We have APAs with 480 and 1148 wires. This fits them in 1 and 3 blocks
       // without being too wasteful.
-      kBlockSize = 512
+      kBlockSize = 512,
+      kTotBytes = MipMapOffset(1, kArenaSize)+4 // leave space for 1x1 as well
     };
 
     PNGArena(const std::string& name);
 
     inline png_byte& operator()(int i, int x, int y, int c)
     {
-      return data[i][(y*extent+x)*4+c];
+      return (*data[i])[(y*kArenaSize+x)*4+c];
     }
 
     inline const png_byte& operator()(int i, int x, int y, int c) const
     {
-      return data[i][(y*extent+x)*4+c];
+      return (*data[i])[(y*kArenaSize+x)*4+c];
     }
 
+    void WritePNGBytes(FILE* fout, int imgIdx, int dim);
+
     png_byte* NewBlock();
-    
+
+    //  protected:
     std::string name;
-    int extent;
     int elemx, elemy;
     int nviews;
 
-    std::vector<std::vector<png_byte>> data;
+    std::vector<std::unique_ptr<std::array<png_byte, kTotBytes>>> data;
+
+  protected:
+    void FillMipMaps(int d);
+
+    std::vector<std::mutex*> fMIPLocks;
+    std::vector<bool> fHasMIP;
   };
 
 
@@ -57,7 +76,7 @@ namespace evd
       const int ix = x/PNGArena::kBlockSize;
       const int iy = y/PNGArena::kBlockSize;
       if(!blocks[ix][iy]) blocks[ix][iy] = arena.NewBlock();
-      return blocks[ix][iy][((y-iy*PNGArena::kBlockSize)*arena.extent+(x-ix*PNGArena::kBlockSize))*4+c];
+      return blocks[ix][iy][((y-iy*PNGArena::kBlockSize)*PNGArena::kArenaSize+(x-ix*PNGArena::kBlockSize))*4+c];
     }
 
     inline png_byte operator()(int x, int y, int c) const
@@ -65,7 +84,7 @@ namespace evd
       const int ix = x/PNGArena::kBlockSize;
       const int iy = y/PNGArena::kBlockSize;
       if(!blocks[ix][iy]) return 0;
-      return blocks[ix][iy][((y-iy*PNGArena::kBlockSize)*arena.extent+(x-ix*PNGArena::kBlockSize))*4+c];
+      return blocks[ix][iy][((y-iy*PNGArena::kBlockSize)*PNGArena::kArenaSize+(x-ix*PNGArena::kBlockSize))*4+c];
     }
 
   protected:
@@ -76,19 +95,7 @@ namespace evd
     std::vector<std::vector<png_byte*>> blocks;
   };
 
-
-  void MipMap(PNGArena& bytes, int newdim);
-
   void AnalyzeArena(const PNGArena& bytes);
-
-  void WriteToPNG(Temporaries& tmp,
-                  const std::string& prefix,
-                  const PNGArena& bytes,
-                  int mipmapdim = -1);
-
-  // NB: destroys "bytes" in the process
-  void WriteToPNGWithMipMaps(Temporaries& tmp,
-                             const std::string& prefix, PNGArena& bytes);
 
 } // namespace
 

--- a/webevd/WebEVD/PNGArena.h
+++ b/webevd/WebEVD/PNGArena.h
@@ -3,6 +3,7 @@
 
 #include "webevd/WebEVD/Temporaries.h"
 
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>

--- a/webevd/WebEVD/WebEVDServer.h
+++ b/webevd/WebEVD/WebEVDServer.h
@@ -11,6 +11,9 @@ namespace detinfo{class DetectorProperties;}
 
 namespace evd
 {
+  class PNGArena;
+  class PNGServer;
+
   enum EResult{kNEXT, kPREV, kQUIT, kERROR, kSEEK};
   struct Result{
     Result(EResult c) : code(c) {}
@@ -34,9 +37,10 @@ namespace evd
     void WriteFiles(const T& evt,
                     const geo::GeometryCore* geom,
                     const detinfo::DetectorProperties* detprop,
-                    Temporaries& tmp);
+                    Temporaries& tmp,
+                    PNGArena& arena);
 
-    Result do_serve(Temporaries& tmp);
+    Result do_serve(Temporaries& tmp, PNGArena& arena);
 
     int EnsureListen();
 

--- a/webevd/WebEVD/web/evd.js
+++ b/webevd/WebEVD/web/evd.js
@@ -154,7 +154,7 @@ function FinalizeTextures(){
             let mat = gtexmats[fname].mat;
             let texdim = gtexmats[fname].texdim;
             if(texdim < d) continue;
-            new THREE.TextureLoader().load(fname+'_mip'+d+'.png',
+            new THREE.TextureLoader().load(fname+'_'+d+'.png',
                                            function(t){
                                                TextureLoadCallback(t, mat, d, texdim);
                                            },


### PR DESCRIPTION
Don't wait for PNGs to be processed before being ready to serve the page. Instead, encode pngs on demand, and write them directly to the network socket without an intermediate file. This gives better interactive performance.