### PR TITLE
Use gallery::Event::getInputTags() now available with gallery 1.16.02

### DIFF
--- a/webevd/WebEVD/WebEVDServer.cxx
+++ b/webevd/WebEVD/WebEVDServer.cxx
@@ -479,20 +479,7 @@ getInputTags(const art::Event& evt)
 template<class T> std::vector<art::InputTag>
 getInputTags(const gallery::Event& evt)
 {
-  std::string label = "pandora";
-  if constexpr(std::is_same_v<T, recob::Hit>) label = "gaushit";
-
-  std::cout << "Warning: getInputTags() not supported by gallery (https://cdcvs.fnal.gov/redmine/issues/23615) defaulting to \"" << label << "\"" << std::endl;
-
-  try{
-    evt.getValidHandle<std::vector<T>>(art::InputTag(label));
-  }
-  catch(...){
-    std::cout << "...but \"" << label << "\" not found in file" << std::endl;
-    return {};
-  }
-
-  return {art::InputTag(label)};
+  return evt.getInputTags<std::vector<T>>();
 }
 
 // ----------------------------------------------------------------------------
@@ -504,6 +491,9 @@ SerializeProduct(const TEvt& evt,
   if(!label.empty()) json << "var " << label << " = {\n"; else json << "{";
 
   const std::vector<art::InputTag> tags = getInputTags<TProd>(evt);
+  // TODO I have no idea why I can't just write
+  // tags = evt.getInputTags<std::vector<TProd>>();
+
   for(const art::InputTag& tag: tags){
     json << "  " << tag << ": ";
 

--- a/webevd/WebEVD/WebEVDServer.cxx
+++ b/webevd/WebEVD/WebEVDServer.cxx
@@ -469,20 +469,6 @@ JSONFormatter& operator<<(JSONFormatter& os, const PNGView& v)
 }
 
 // ----------------------------------------------------------------------------
-template<class T> std::vector<art::InputTag>
-getInputTags(const art::Event& evt)
-{
-  return evt.getInputTags<std::vector<T>>();
-}
-
-// ----------------------------------------------------------------------------
-template<class T> std::vector<art::InputTag>
-getInputTags(const gallery::Event& evt)
-{
-  return evt.getInputTags<std::vector<T>>();
-}
-
-// ----------------------------------------------------------------------------
 template<class TProd, class TEvt> void
 SerializeProduct(const TEvt& evt,
                  JSONFormatter& json,
@@ -490,9 +476,7 @@ SerializeProduct(const TEvt& evt,
 {
   if(!label.empty()) json << "var " << label << " = {\n"; else json << "{";
 
-  const std::vector<art::InputTag> tags = getInputTags<TProd>(evt);
-  // TODO I have no idea why I can't just write
-  // tags = evt.getInputTags<std::vector<TProd>>();
+  const std::vector<art::InputTag> tags = evt.template getInputTags<std::vector<TProd>>();
 
   for(const art::InputTag& tag: tags){
     json << "  " << tag << ": ";
@@ -616,7 +600,7 @@ SerializeHits(const T& evt, const geo::GeometryCore* geom, JSONFormatter& json)
 {
   std::map<art::InputTag, std::map<geo::PlaneID, std::vector<recob::Hit>>> plane_hits;
 
-  for(art::InputTag tag: getInputTags<recob::Hit>(evt)){
+  for(art::InputTag tag: evt.template getInputTags<std::vector<recob::Hit>>()){
     typename T::template HandleT<std::vector<recob::Hit>> hits; // deduce handle type
     evt.getByLabel(tag, hits);
 
@@ -778,7 +762,7 @@ protected:
 
     if(!fEvt || !fGeom) return; // already init'd
 
-    for(art::InputTag tag: getInputTags<raw::RawDigit>(*fEvt)){
+    for(art::InputTag tag: fEvt->template getInputTags<std::vector<raw::RawDigit>>()){
       typename T::template HandleT<std::vector<raw::RawDigit>> digs; // deduce handle type
       fEvt->getByLabel(tag, digs);
 
@@ -859,7 +843,7 @@ protected:
 
     if(!fEvt || !fGeom) return; // already init'd
 
-    for(art::InputTag tag: getInputTags<recob::Wire>(*fEvt)){
+    for(art::InputTag tag: fEvt->template getInputTags<std::vector<recob::Wire>>()){
       typename T::template HandleT<std::vector<recob::Wire>> wires; // deduce handle type
       fEvt->getByLabel(tag, wires);
 


### PR DESCRIPTION
This means the gallery version of the event display now has access to all the product labels instead of having to hardcode them.