### PR TITLE
Workaround JSON having no way to represent inf/nan

### DIFF
--- a/webevd/WebEVD/JSONFormatter.h
+++ b/webevd/WebEVD/JSONFormatter.h
@@ -28,8 +28,12 @@ public:
 
   JSONFormatter& operator<<(double x)
   {
-    if(isnan(x)) fStream << "NaN";
-    else if(isinf(x)) fStream << "Infinity";
+    // "NaN" and "Infinity" are the javascript syntax, but JSON doesn't include
+    // these concepts at all. Our options are to send a string, a null, or a
+    // number that is unrepresentable and will become Infinity again. I don't
+    // know any way to play the same trick with a NaN.
+    if(isnan(x)) fStream << "1e999";
+    else if(isinf(x)) fStream << "1e999";
     else fStream << x;
     return *this;
   }


### PR DESCRIPTION
Workaround JSON having no way to represent inf/nan. Otherwise serialization of any object containing inf/nan makes the whole json it's contained in malformed.