### PR TITLE
Work out size of PNGView structure on demand

### DIFF
--- a/webevd/WebEVD/PNGArena.cxx
+++ b/webevd/WebEVD/PNGArena.cxx
@@ -161,8 +161,7 @@ namespace evd
   }
 
   // --------------------------------------------------------------------------
-  PNGView::PNGView(PNGArena& a, int w, int h)
-    : arena(a), width(w), height(h), blocks(w/PNGArena::kBlockSize+1, std::vector<png_byte*>(h/PNGArena::kBlockSize+1, 0))
+  PNGView::PNGView(PNGArena& a) : arena(a)
   {
   }
 

--- a/webevd/WebEVD/PNGArena.h
+++ b/webevd/WebEVD/PNGArena.h
@@ -69,20 +69,24 @@ namespace evd
   class PNGView
   {
   public:
-    PNGView(PNGArena& a, int w, int h);
+    explicit PNGView(PNGArena& a);
 
     inline png_byte& operator()(int x, int y, int c)
     {
-      const int ix = x/PNGArena::kBlockSize;
-      const int iy = y/PNGArena::kBlockSize;
+      const unsigned int ix = x/PNGArena::kBlockSize;
+      const unsigned int iy = y/PNGArena::kBlockSize;
+      if(ix >= blocks.size()) blocks.resize(ix+1);
+      if(iy >= blocks[ix].size()) blocks[ix].resize(iy+1, 0);
       if(!blocks[ix][iy]) blocks[ix][iy] = arena.NewBlock();
       return blocks[ix][iy][((y-iy*PNGArena::kBlockSize)*PNGArena::kArenaSize+(x-ix*PNGArena::kBlockSize))*4+c];
     }
 
     inline png_byte operator()(int x, int y, int c) const
     {
-      const int ix = x/PNGArena::kBlockSize;
-      const int iy = y/PNGArena::kBlockSize;
+      const unsigned int ix = x/PNGArena::kBlockSize;
+      const unsigned int iy = y/PNGArena::kBlockSize;
+      if(ix >= blocks.size()) return 0;
+      if(iy >= blocks[ix].size()) return 0;
       if(!blocks[ix][iy]) return 0;
       return blocks[ix][iy][((y-iy*PNGArena::kBlockSize)*PNGArena::kArenaSize+(x-ix*PNGArena::kBlockSize))*4+c];
     }
@@ -91,7 +95,7 @@ namespace evd
     friend JSONFormatter& operator<<(JSONFormatter&, const PNGView&);
 
     PNGArena& arena;
-    int width, height;
+
     std::vector<std::vector<png_byte*>> blocks;
   };
 

--- a/webevd/WebEVD/WebEVDServer.cxx
+++ b/webevd/WebEVD/WebEVDServer.cxx
@@ -891,10 +891,9 @@ protected:
           const geo::PlaneID plane(wire);
 
           const geo::WireID w0 = fGeom->GetBeginWireID(plane);
-          const unsigned int Nw = fGeom->Nwires(plane);
 
           if(fImgs[tag].count(plane) == 0){
-            fImgs[tag].emplace(plane, PNGView(fArena, Nw, dig.Samples()));
+            fImgs[tag].emplace(plane, PNGView(fArena));
           }
 
           PNGView& bytes = fImgs[tag].find(plane)->second;
@@ -973,10 +972,9 @@ protected:
           const geo::PlaneID plane(wire);
 
           const geo::WireID w0 = fGeom->GetBeginWireID(plane);
-          const unsigned int Nw = fGeom->Nwires(plane);
 
           if(fImgs[tag].count(plane) == 0){
-            fImgs[tag].emplace(plane, PNGView(fArena, Nw, rbwire.NSignal()));
+            fImgs[tag].emplace(plane, PNGView(fArena));
           }
 
           PNGView& bytes = fImgs[tag].find(plane)->second;


### PR DESCRIPTION
This is necessary for ICARUS data, where there apparently exist Wire objects with different numbers of ticks.